### PR TITLE
drive practice updates

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -25,7 +25,7 @@ public final class Constants {
     public static final int backRightMotor = 4;
 
     //idk where this number came from but it's been the same for the past 2 years
-    public static final double rampRate = 0.5;
+    public static final double rampRate = 0.75;
     public static double kDistancePerWheelRevolutionMeters = Units.inchesToMeters(6*Math.PI);
     public static double kGearReduction = 10.71;
     public static double ksVolts = 0;
@@ -44,6 +44,11 @@ public final class Constants {
     public static final double pivotMotorPower = 0.2;
     public static final int armMotor = 7;
     public static final double armMotorPower = 0.2;
+
+    public static final float pivotLimitIn = 0.0f;
+    public static final float pivotLimitOut = 26.0f; // this will be negated in the subsystem because negative means out
+    public static final float armLimitIn = 0.0f;
+    public static final float armLimitOut = 9.5f; // this will remain positive in the subsystem because positive means out
   }
 
   public static final class JoystickConstants {

--- a/src/main/java/frc/robot/subsystems/Booty_Intake.java
+++ b/src/main/java/frc/robot/subsystems/Booty_Intake.java
@@ -71,19 +71,19 @@ public class Booty_Intake extends SubsystemBase {
 
     if(_state == BootyState.Off) {
       _power = 0.0;
-      currentLimit = 40;
+      currentLimit = 55;
     }else if(_state == BootyState.CubeIntake) {
       _power =0.25;
-      currentLimit = 40;
+      currentLimit = 55;
     } else if (_state == BootyState.ConeIntake) {
-      _power = -0.40;
-      currentLimit = 40;
+      _power = -0.60;
+      currentLimit = 55;
     } else if (_state == BootyState.CubeHold) {
-      _power = 0.07;
-      currentLimit = 15;
+      _power = 0.10;
+      currentLimit = 20;
     } else if (_state == BootyState.ConeHold) {
-      _power = -0.07;
-      currentLimit = 15;
+      _power = -0.12;
+      currentLimit = 20;
     } 
 
     _intakeMotor.set(_power);

--- a/src/main/java/frc/robot/subsystems/Drive_Train.java
+++ b/src/main/java/frc/robot/subsystems/Drive_Train.java
@@ -56,7 +56,7 @@ public class Drive_Train extends SubsystemBase {
     _bLMotor.follow(_fLMotor);
     _bRMotor.follow(_fRMotor);
 
-    enableOpenLoopRampRate(false);
+    enableOpenLoopRampRate(true);
 
     _leftEncoder = _fLMotor.getEncoder();
     _rightEncoder = _fRMotor.getEncoder();

--- a/src/main/java/frc/robot/subsystems/FourBarArms.java
+++ b/src/main/java/frc/robot/subsystems/FourBarArms.java
@@ -6,12 +6,15 @@ package frc.robot.subsystems;
 
 import com.revrobotics.CANSparkMax;
 import com.revrobotics.RelativeEncoder;
+import com.revrobotics.CANSparkMax.IdleMode;
+import com.revrobotics.CANSparkMax.SoftLimitDirection;
 import com.revrobotics.CANSparkMaxLowLevel.MotorType;
 
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.RunCommand;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;
+import frc.robot.Constants.IntakeConstants;
 
 public class FourBarArms extends SubsystemBase {
   private final CANSparkMax _armMotor = new CANSparkMax(Constants.IntakeConstants.armMotor, MotorType.kBrushless);
@@ -24,7 +27,11 @@ public class FourBarArms extends SubsystemBase {
     setDefaultCommand(new RunCommand(this::stop, this));
 
     _armMotor.restoreFactoryDefaults();
-
+    _armMotor.setIdleMode(IdleMode.kBrake);
+    _armMotor.enableSoftLimit(SoftLimitDirection.kReverse, true);
+    _armMotor.setSoftLimit(SoftLimitDirection.kReverse, IntakeConstants.armLimitIn);
+    _armMotor.enableSoftLimit(SoftLimitDirection.kForward, true);
+    _armMotor.setSoftLimit(SoftLimitDirection.kForward, IntakeConstants.armLimitOut);
     _armMotor.burnFlash();
   }
 
@@ -55,5 +62,6 @@ public class FourBarArms extends SubsystemBase {
   @Override
   public void periodic() {
     SmartDashboard.putNumber("Arm Position", _encoder.getPosition());
+    SmartDashboard.putNumber("Arm Current", _armMotor.getOutputCurrent());
   }
 }

--- a/src/main/java/frc/robot/subsystems/IntakePivot.java
+++ b/src/main/java/frc/robot/subsystems/IntakePivot.java
@@ -5,11 +5,15 @@
 package frc.robot.subsystems;
 
 import com.revrobotics.CANSparkMax;
+import com.revrobotics.CANSparkMax.IdleMode;
+import com.revrobotics.CANSparkMax.SoftLimitDirection;
 import com.revrobotics.CANSparkMaxLowLevel.MotorType;
 
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.RunCommand;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;
+import frc.robot.Constants.IntakeConstants;
 
 public class IntakePivot extends SubsystemBase {
   private final CANSparkMax _pivotMotor = new CANSparkMax(Constants.IntakeConstants.pivotMotor, MotorType.kBrushless);
@@ -21,7 +25,11 @@ public class IntakePivot extends SubsystemBase {
     setDefaultCommand(new RunCommand(this::stop, this));
 
     _pivotMotor.restoreFactoryDefaults();
-
+    _pivotMotor.setIdleMode(IdleMode.kBrake);
+    _pivotMotor.enableSoftLimit(SoftLimitDirection.kReverse, true);
+    _pivotMotor.setSoftLimit(SoftLimitDirection.kReverse, -IntakeConstants.pivotLimitIn);
+    _pivotMotor.enableSoftLimit(SoftLimitDirection.kForward, true);
+    _pivotMotor.setSoftLimit(SoftLimitDirection.kForward, IntakeConstants.pivotLimitOut);
     _pivotMotor.burnFlash();
   }
 
@@ -44,5 +52,7 @@ public class IntakePivot extends SubsystemBase {
   @Override
   public void periodic() {
     // This method will be called once per scheduler run
+    SmartDashboard.putNumber("Pivot Position", _pivotMotor.getEncoder().getPosition());
+    SmartDashboard.putNumber("Pivot Current", _pivotMotor.getOutputCurrent());
   }
 }


### PR DESCRIPTION
- Adjusted intake powers and current limits (cone was not intaking or holding properly)
- Enabled open loop ramp rate on drive train to minimize risk of tipping
- Enabled and set soft limits for arm and intake pivot, allowing the operator to hold the button without the worry of overextending the mechanism
- Explicitly set idle mode to brake for arm and intake pivot (arm controller was in coast mode, causing it to flop out at inopportune times)